### PR TITLE
feat: navigation refresh

### DIFF
--- a/src/styles/components/Navigation.scss
+++ b/src/styles/components/Navigation.scss
@@ -2,6 +2,7 @@
 
 @layer components {
 	.Navigation {
+		margin-bottom: 1rem;
 		&__items {
 			display: none;
 			gap: 1.5rem;
@@ -101,9 +102,14 @@
 			.Navigation__items {
 				@media screen and (min-width: 48rem) {
 					background-color: white;
+					border: 1px solid #e5e7eb;
+					border-radius: 0.375rem;
+					box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 					display: none;
 					flex-direction: column;
 					gap: 0;
+					overflow: hidden;
+					// padding-block: 0.25rem;
 					position: absolute;
 					z-index: 100;
 				}
@@ -112,15 +118,15 @@
 					display: block;
 
 					@media screen and (min-width: 48rem) {
-						padding: 8px 16px;
+						padding: 0.5rem 1rem;
 						text-decoration: none;
+						transition: background-color 120ms ease;
 					}
 
 					&:hover,
 					&[aria-current] {
 						@media screen and (min-width: 48rem) {
 							background-color: variables.$color--primary;
-							// TODO !important
 							color: white !important;
 						}
 					}

--- a/src/styles/components/Navigation.scss
+++ b/src/styles/components/Navigation.scss
@@ -109,7 +109,6 @@
 					flex-direction: column;
 					gap: 0;
 					overflow: hidden;
-					// padding-block: 0.25rem;
 					position: absolute;
 					z-index: 100;
 				}

--- a/src/styles/page/PageHeader.scss
+++ b/src/styles/page/PageHeader.scss
@@ -4,7 +4,7 @@
 		padding: 20px;
 
 		.container {
-			align-items: center;
+			align-items: flex-end;
 			display: flex;
 			gap: 2rem;
 			justify-content: space-between;


### PR DESCRIPTION
I appreciate this wasn't asked for 😄 but wanted to try to refresh the nav just a little bit. Feel free to close if you don't like this direction.

- Aligns nav with bottom of logo, rather than floating a little awkwardly in space
- Tweaks dropdown styles to make them a little less "boxy"

---

<img width="1523" height="296" alt="Screenshot 2026-04-06 at 23 04 44" src="https://github.com/user-attachments/assets/4d43e2e4-8bb8-41c3-9c7b-235f366b7b06" />

---

Hover:

<img width="1520" height="287" alt="Screenshot 2026-04-06 at 23 04 52" src="https://github.com/user-attachments/assets/13bb7f88-1762-485a-b023-f045e796102d" />
