### PR TITLE
fix: Sites index renders correctly sized thumbnail

### DIFF
--- a/src/pages/sites/index.astro
+++ b/src/pages/sites/index.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
+import { Image } from 'astro:assets';
 import Layout from '../../layouts/Layout.astro';
 import { siteConfig } from '../../config';
 import { toKebabCase } from '../../helpers';
@@ -15,14 +16,23 @@ const allApiSites = await apiResponse.json();
 // Filter out ignored sites
 const apiSites = allApiSites.filter((site: any) => !siteConfig.ignoredSites.includes(site.name));
 
-// Get collection for tags
+// Get collection for tags and local images
 const siteMeta = await getCollection('siteMeta');
-const siteTagsMap = new Map(siteMeta.map((site) => [site.id, site.data.tags || []]));
+const siteMetaMap = new Map(
+	siteMeta.map((site) => [
+		site.id,
+		{
+			tags: site.data.tags || [],
+			thumbnail: site.data.images?.[0] || null,
+		},
+	])
+);
 
 // Map API data with first image and tags
 const sites = apiSites
 	.map((site: any) => {
 		const slug = toKebabCase(site.name);
+		const meta = siteMetaMap.get(slug);
 
 		return {
 			slug,
@@ -33,14 +43,18 @@ const sites = apiSites
 			url: site.url,
 			allocatedUnits: site.allocatedUnits,
 			coordinates: site.coordinates,
-			thumbnail: site.images?.[0] || null,
-			tags: siteTagsMap.get(slug) || [],
+			localThumbnail: meta?.thumbnail || null,
+			remoteThumbnail: site.images?.[0] || null,
+			tags: meta?.tags || [],
 		};
 	})
 	.sort((a: any, b: any) => a.name.localeCompare(b.name));
 
 // Get all unique tags
 const allTags = [...new Set(sites.flatMap((site: any) => site.tags))].sort();
+
+// Strip image metadata from sites, which isn't needed for Mapbox
+const mapSites = sites.map(({ localThumbnail, remoteThumbnail, ...rest }: any) => rest);
 ---
 
 <Layout title="Sites">
@@ -93,8 +107,16 @@ const allTags = [...new Set(sites.flatMap((site: any) => site.tags))].sort();
 					sites.map((site: any) => (
 						<article class="Site" data-tags={JSON.stringify(site.tags)}>
 							<aside class="Site__thumbnail">
-								{site.thumbnail ? (
-									<img src={site.thumbnail} alt="" />
+								{site.localThumbnail ? (
+									<Image
+										src={site.localThumbnail}
+										alt=""
+										width={600}
+										height={338}
+										loading="lazy"
+									/>
+								) : site.remoteThumbnail ? (
+									<img src={site.remoteThumbnail} alt="" loading="lazy" />
 								) : (
 									<svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
 										<path
@@ -143,7 +165,7 @@ const allTags = [...new Set(sites.flatMap((site: any) => site.tags))].sort();
 <!-- Mapbox GL JS -->
 <link href="https://api.mapbox.com/mapbox-gl-js/v2.8.2/mapbox-gl.css" rel="stylesheet" />
 <script src="https://api.mapbox.com/mapbox-gl-js/v2.8.2/mapbox-gl.js"></script>
-<script is:inline define:vars={{ sites, mapboxToken }}>
+<script is:inline define:vars={{ sites: mapSites, mapboxToken }}>
 	window.addEventListener('DOMContentLoaded', () => {
 		mapboxgl.accessToken = mapboxToken;
 


### PR DESCRIPTION
Closes: https://github.com/protect-earth/website/issues/18

This takes https://protect-earth-website.netlify.app/sites/ from 145.64 MB down to 5.94 MB. 

(additional work could be done in future to further optimise the images, but I did for now enable lazy loading on the images so they only load when scrolled to / past)

Most sites already have images stored in the repo, and processed by Astro, but the Sites page was using the thumbnail URLs returned by the API (eg. `https://fls-9fae57b9-b1e4-47db-b43e-c1bf4c342bcd.laravel.cloud/sites/XY/site-name-abc-xyz.jpg`) which are all pretty massive.

These images are already being fetched locally and stored in the project / repo via `pnpm sync-sites:replace-images`, so we can utilise these instead.

This change ensures that, where there is a local image, it is used, and if not it falls back to the API's thumbnail URL (Laraval Cloud).

Since we don't need all of this additional image metadata for the Mapbox map, I've stripped that out and pass `sites: mapSites` [instead](https://github.com/protect-earth/website/pull/19/changes#diff-091791a95a4239f3623e1bf5e0fcfb5fb578c78ecf83670004f0138a3bc4eb37R168).