### PR TITLE
Normalize font sizes and responsive homepage nav

### DIFF
--- a/src/components/ImageGallery.astro
+++ b/src/components/ImageGallery.astro
@@ -83,7 +83,9 @@ if (!images || images.length === 0) {
 	</div>
 </div>
 
-<style>
+<style lang="scss">
+	@use '../styles/variables';
+
 	/* TODO Remove */
 	.h-8 {
 		height: 2rem;
@@ -208,7 +210,7 @@ if (!images || images.length === 0) {
 	.lightbox-counter {
 		margin-top: 1rem;
 		color: white;
-		font-size: 1.125rem;
+		font-size: variables.$text--md;
 		font-weight: 600;
 		text-align: center;
 		padding: 0.5rem 1rem;

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -12,7 +12,6 @@ const { currentPage, lastPage, url } = Astro.props;
 			<a
 				class="Pagination__link Pagination__link--previous"
 				href={url.prev}
-				class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition"
 			>
 				<svg class="Pagination__icon icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 					<path

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -134,15 +134,15 @@ import ContentHero from '../components/ContentHero.astro';
 		<div class="PageSection__content">
 			<nav class="PanelLinks">
 				<a href="/get-involved/people-families" class="PanelLinks__link">
-					<strong class="text-xl font-bold mb-2">Volunteer</strong>
+					<strong class="font-bold mb-2">Volunteer</strong>
 					<span>Join us at tree planting events and woodland maintenance days</span>
 				</a>
 				<a href="/act-now/general-donation" class="PanelLinks__link">
-					<strong class="text-xl font-bold mb-2">Donate</strong>
+					<strong class="font-bold mb-2">Donate</strong>
 					<span> Support our work creating and restoring woodlands across the UK </span>
 				</a>
 				<a href="/get-involved/landowners" class="PanelLinks__link">
-					<strong class="text-xl font-bold mb-2">Landowners</strong>
+					<strong class="font-bold mb-2">Landowners</strong>
 					<span>Have land you'd like to see transformed into woodland?</span>
 				</a>
 			</nav>

--- a/src/pages/join-our-mailing-list.astro
+++ b/src/pages/join-our-mailing-list.astro
@@ -82,7 +82,7 @@ import Layout from '../layouts/Layout.astro';
 				<!-- Success/Error Messages -->
 				<div id="form-message" aria-live="assertive" class="form-message"></div>
 
-				<footer class="mt-8 text-center text-sm text-gray-600">
+				<footer class="mt-8 text-center text-gray-600">
 					<small>
 						We respect your privacy. Your information will only be used to send you updates about
 						Protect Earth's conservation work.

--- a/src/pages/people-and-families/well-help-you-buy-land.astro
+++ b/src/pages/people-and-families/well-help-you-buy-land.astro
@@ -10,7 +10,7 @@ import CallToAction from '../../components/CallToAction.astro';
 			<img src="/hero-buy-land.jpg" alt="Rolling green hills and fields with trees and fences" class="w-full h-full object-cover opacity-60" />
 		</div>
 		<div class="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
-			<h1 class="text-5xl font-bold mb-6">We'll Help You Buy Land</h1>
+			<h1 class="WellHelp__title font-bold mb-6">We'll Help You Buy Land</h1>
 		</div>
 	</section>
 
@@ -18,19 +18,19 @@ import CallToAction from '../../components/CallToAction.astro';
 	<section class="py-16 bg-white">
 		<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
 			<div class="prose prose-lg max-w-none">
-				<p class="text-xl text-gray-700 mb-6">
+				<p class="WellHelp__body text-gray-700 mb-6">
 					Finding the right land to reforest, rewet or rewild can be a challenge. The last thing we want is for well-intentioned efforts to do damage to our native ecosystems – like planting trees in a peat bog, for example.
 				</p>
 				
-				<p class="text-xl text-gray-700 mb-6">
+				<p class="WellHelp__body text-gray-700 mb-6">
 					If you're on the lookout for land to restore, Protect Earth is here to help. We can assist you in finding a suitable site close to home, and help you avoid areas with designations that might conflict with your restoration plans. Our team will guide you through the purchasing process, ensuring everything aligns with your goals.
 				</p>
 				
-				<p class="text-xl text-gray-700 mb-6">
+				<p class="WellHelp__body text-gray-700 mb-6">
 					Once you've secured the land, we'll walk you through ensuing steps, including:
 				</p>
 				
-				<ul class="text-lg text-gray-700 mb-6 space-y-2 list-disc pl-6">
+				<ul class="WellHelp__list text-gray-700 mb-6 space-y-2 list-disc pl-6">
 					<li>Registering the land with authorities.</li>
 					<li>Bringing in an ecologist for an assessment.</li>
 					<li>Conducting environmental impact assessments.</li>
@@ -39,12 +39,12 @@ import CallToAction from '../../components/CallToAction.astro';
 					<li>Overseeing the planting process and helping with long-term maintenance.</li>
 				</ul>
 				
-				<p class="text-xl text-gray-700 mb-8">
+				<p class="WellHelp__body text-gray-700 mb-8">
 					Whether you want us to be deeply involved or prefer more hands-off support, we'll provide as much help as you need to make sure your land restoration project succeeds.
 				</p>
 				
 				<div class="text-center">
-					<a href="/contact" class="inline-block bg-green-700 text-white px-8 py-4 rounded-lg hover:bg-green-800 transition font-semibold text-lg">
+					<a href="/contact" class="WellHelp__cta inline-block bg-green-700 text-white px-8 py-4 rounded-lg hover:bg-green-800 transition font-semibold">
 						Get in Touch
 					</a>
 				</div>
@@ -54,3 +54,20 @@ import CallToAction from '../../components/CallToAction.astro';
 
 	<CallToAction />
 </Layout>
+
+<style lang="scss">
+	@use '../../styles/variables';
+
+	.WellHelp__title {
+		font-size: variables.$text--3xl;
+	}
+
+	.WellHelp__body {
+		font-size: variables.$text--lg;
+	}
+
+	.WellHelp__list,
+	.WellHelp__cta {
+		font-size: variables.$text--md;
+	}
+</style>

--- a/src/pages/sites/[slug].astro
+++ b/src/pages/sites/[slug].astro
@@ -179,7 +179,7 @@ const fundingPartnerInfos = fundingPartners
 		siteUpdates.length > 0 && (
 			<section class="PageSection SiteUpdates">
 				<header class="PageSection__header">
-					<h2 class="PageSection__title text-3xl font-bold mb-8 text-gray-900">
+					<h2 class="PageSection__title font-bold mb-8 text-gray-900">
 						<span aria-hidden>📝</span>
 						Site Updates
 					</h2>

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -15,3 +15,13 @@ $inline--md: 48rem; // 768px
 $inline--lg: 64rem; // 1024px
 $inline--xl: 80rem; // 1280px
 $inline--2xl: 96rem; // 1536px
+
+$text--2xs: 0.75rem;
+$text--xs: 0.875rem;
+$text--sm: 1rem;
+$text--md: 1.125rem;
+$text--lg: 1.25rem;
+$text--xl: 1.5rem;
+$text--2xl: 1.875rem;
+$text--3xl: 3rem;
+$text--display: 6rem;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -24,4 +24,4 @@ $text--lg: 1.25rem;
 $text--xl: 1.5rem;
 $text--2xl: 1.875rem;
 $text--3xl: 3rem;
-$text--display: 6rem;
+$text--display: 5rem;

--- a/src/styles/components/Achievements.scss
+++ b/src/styles/components/Achievements.scss
@@ -10,6 +10,13 @@
 		max-inline-size: variables.$max--inline-size;
 	}
 
+	@media screen and (max-width: 48rem) {
+		&s {
+			grid-template-columns: auto;
+			grid-template-rows: repeat(3, 1fr);
+		}
+	}
+
 	text-align: center;
 
 	&__value,
@@ -27,3 +34,4 @@
 		margin-block-start: 0.5rem;
 	}
 }
+

--- a/src/styles/components/Achievements.scss
+++ b/src/styles/components/Achievements.scss
@@ -19,11 +19,11 @@
 	}
 
 	&__value {
-		font-size: 6rem;
+		font-size: variables.$text--display;
 	}
 
 	&__label {
-		font-size: 1.5rem;
+		font-size: variables.$text--xl;
 		margin-block-start: 0.5rem;
 	}
 }

--- a/src/styles/components/Article.scss
+++ b/src/styles/components/Article.scss
@@ -1,3 +1,5 @@
+@use '../variables';
+
 @layer components {
 	.Article {
 		display: flex;
@@ -8,7 +10,7 @@
 		text-align: left;
 
 		&__title {
-			font-size: 1.125rem;
+			font-size: variables.$text--md;
 			text-wrap: pretty;
 		}
 
@@ -28,7 +30,7 @@
 		}
 
 		&__link {
-			font-size: 0.875rem;
+			font-size: variables.$text--xs;
 			margin-block-start: auto;
 
 			&::before {

--- a/src/styles/components/Navigation.scss
+++ b/src/styles/components/Navigation.scss
@@ -140,7 +140,7 @@
 		}
 
 		&__link {
-			font-size: 1.25rem;
+			font-size: variables.$text--lg;
 			font-weight: 500;
 			text-decoration: none;
 			text-underline-offset: 1rem;

--- a/src/styles/components/PressArticles.scss
+++ b/src/styles/components/PressArticles.scss
@@ -27,7 +27,7 @@
 		}
 
 		&__title {
-			font-size: 1.25rem;
+			font-size: variables.$text--lg;
 			font-weight: 700;
 		}
 

--- a/src/styles/components/Site.scss
+++ b/src/styles/components/Site.scss
@@ -1,10 +1,12 @@
+@use '../variables';
+
 @layer components {
 	.SiteFilter {
 		text-align: left;
 
 		&__title {
 			color: #374151;
-			font-size: 1.125rem;
+			font-size: variables.$text--md;
 			font-weight: 600;
 			line-height: 1.75rem;
 		}
@@ -20,7 +22,7 @@
 			padding: 0.5rem 16px;
 			border-radius: 10rem;
 			border: 2px solid#D1D5DB;
-			font-size: 0.875rem;
+			font-size: variables.$text--xs;
 			line-height: 1.25rem;
 			font-weight: 500;
 			transition-property: color, background-color, border-color;
@@ -43,7 +45,7 @@
 
 		&__results {
 			color: #4b5563;
-			font-size: 0.875rem;
+			font-size: variables.$text--xs;
 			line-height: 1.25rem;
 			margin-block-start: 1rem;
 		}
@@ -86,7 +88,7 @@
 		&__location,
 		&__units,
 		&__link {
-			font-size: 0.875rem;
+			font-size: variables.$text--xs;
 			line-height: 1.25rem;
 		}
 	}
@@ -148,7 +150,7 @@
 
 		&__title {
 			color: #111827;
-			font-size: 1.5rem;
+			font-size: variables.$text--xl;
 			font-weight: 700;
 			line-height: 2rem;
 			position: relative;
@@ -303,7 +305,7 @@
 			}
 
 			&__title {
-				font-size: 1.25rem;
+				font-size: variables.$text--lg;
 				line-height: 1.75rem;
 				font-weight: 600;
 				color: #111827;
@@ -333,7 +335,7 @@
 				border-radius: 10rem;
 				color: var(--SiteUpdateTag--color);
 				display: inline-flex;
-				font-size: 0.875rem;
+				font-size: variables.$text--xs;
 				font-weight: 500;
 				line-height: 1.25rem;
 				padding: 0.25rem 12px;
@@ -425,7 +427,7 @@
 
 			&__title {
 				margin-bottom: 2rem;
-				font-size: 1.875rem;
+				font-size: variables.$text--2xl;
 				line-height: 2.25rem;
 				font-weight: 700;
 				color: #111827;
@@ -466,7 +468,7 @@
 
 				span {
 					color: #1f2937;
-					font-size: 0.875rem;
+					font-size: variables.$text--xs;
 					font-weight: 500;
 					line-height: 1.25rem;
 					text-align: center;
@@ -481,7 +483,7 @@
 
 			&__title {
 				margin-block-end: 2rem;
-				font-size: 1.875rem;
+				font-size: variables.$text--2xl;
 				line-height: 2.25rem;
 				font-weight: 700;
 				text-align: center;

--- a/src/styles/components/Site.scss
+++ b/src/styles/components/Site.scss
@@ -181,7 +181,7 @@
 			border-radius: 10rem;
 			color: #065f46;
 			display: inline-block;
-			font-size: 0.75rem;
+			font-size: variables.$text--2xs;
 			font-weight: 500;
 			line-height: 1rem;
 			padding: 0.25rem 0.75rem;

--- a/src/styles/components/TeamMembers.scss
+++ b/src/styles/components/TeamMembers.scss
@@ -1,3 +1,5 @@
+@use '../variables';
+
 @layer components {
 	.TeamMembers {
 		> * + * {
@@ -21,7 +23,7 @@
 		&__name,
 		&__role {
 			display: inline;
-			font-size: 1.25rem;
+			font-size: variables.$text--lg;
 			font-weight: 700;
 		}
 
@@ -36,7 +38,7 @@
 			margin-block-start: 2rem;
 
 			p {
-				font-size: 1rem;
+				font-size: variables.$text--sm;
 
 				+ p {
 					margin-block-start: 1rem;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -94,7 +94,7 @@
 
 		footer {
 			margin-block-start: 2rem;
-			font-size: 0.875rem;
+			font-size: variables.$text--xs;
 			line-height: 1.25rem;
 			text-align: center;
 			color: #4b5563;
@@ -147,7 +147,7 @@
 	legend,
 	label {
 		color: #111827;
-		font-size: 1rem;
+		font-size: variables.$text--sm;
 		font-weight: 600;
 		line-height: 1.5rem;
 		margin-bottom: 0.75rem;
@@ -224,7 +224,7 @@
 
 		&__subTitle {
 			margin-bottom: 1.5rem;
-			font-size: 1.5rem;
+			font-size: variables.$text--xl;
 			line-height: 2rem;
 			font-weight: 700;
 		}
@@ -242,7 +242,7 @@
 			strong {
 				display: block;
 				margin-bottom: 0.5rem;
-				font-size: 1.25rem;
+				font-size: variables.$text--lg;
 				line-height: 1.75rem;
 				font-weight: 600;
 			}
@@ -265,7 +265,7 @@
 		dl {
 			display: grid;
 			margin-top: 0.875rem;
-			font-size: 1.125rem;
+			font-size: variables.$text--md;
 			line-height: 1.75rem;
 			text-align: left;
 			grid-template-columns: auto 1fr;
@@ -317,7 +317,7 @@
 			strong {
 				display: block;
 				margin-bottom: 0.5rem;
-				font-size: 1.25rem;
+				font-size: variables.$text--lg;
 				font-weight: 700;
 				line-height: 1.75rem;
 			}
@@ -378,7 +378,7 @@
 		border-radius: 0.25rem;
 		color: #ffffff;
 		display: inline-block;
-		font-size: 1.125rem;
+		font-size: variables.$text--md;
 		font-weight: 700;
 		line-height: 1.75rem;
 		padding: 1rem 32px;
@@ -452,17 +452,17 @@
 		}
 
 		h2 {
-			font-size: 1.875rem;
+			font-size: variables.$text--2xl;
 			margin-top: 3rem;
 		}
 
 		h3 {
-			font-size: 1.5rem;
+			font-size: variables.$text--xl;
 			margin-top: 2.5rem;
 		}
 
 		h4 {
-			font-size: 1.25rem;
+			font-size: variables.$text--lg;
 		}
 
 		p {
@@ -471,7 +471,7 @@
 		}
 
 		p:first-of-type {
-			font-size: 1.25rem;
+			font-size: variables.$text--lg;
 		}
 
 		img {
@@ -517,7 +517,7 @@
 			background-color: rgb(243 244 246);
 			padding: 0.125rem 0.25rem;
 			border-radius: 0.25rem;
-			font-size: 0.875rem;
+			font-size: variables.$text--xs;
 		}
 
 		strong {

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -100,7 +100,7 @@
 			color: #4b5563;
 
 			small {
-				font-size: 100%;
+				font-size: variables.$text--sm;
 			}
 		}
 

--- a/src/styles/page/ContentBlock.scss
+++ b/src/styles/page/ContentBlock.scss
@@ -43,18 +43,18 @@
 		}
 
 		&__title {
-			font-size: 1.625rem;
+			font-size: variables.$text--xl;
 			font-weight: 700;
 			line-height: 1.2;
 
 			@media screen and (min-width: #{variables.$inline--md}) {
-				font-size: 2rem;
+				font-size: variables.$text--2xl;
 			}
 		}
 
 		&__content {
 			color: #374151;
-			font-size: 1.0625rem;
+			font-size: variables.$text--sm;
 			line-height: 1.75;
 			margin-block-start: 1rem;
 
@@ -119,7 +119,7 @@
 				}
 
 				&__content {
-					font-size: 1.1875rem;
+					font-size: variables.$text--md;
 					line-height: 1.8;
 				}
 			}

--- a/src/styles/page/ContentHero.scss
+++ b/src/styles/page/ContentHero.scss
@@ -34,7 +34,7 @@
 			}
 
 			p {
-				font-size: 1.5rem;
+				font-size: variables.$text--xl;
 				line-height: 1.625;
 				margin-inline: auto;
 				max-inline-size: 48rem;
@@ -46,7 +46,7 @@
 		}
 
 		&__title {
-			font-size: 3rem;
+			font-size: variables.$text--3xl;
 			font-weight: bold;
 			line-height: 1;
 			margin-block-end: 1.5rem;

--- a/src/styles/page/Footer.scss
+++ b/src/styles/page/Footer.scss
@@ -12,7 +12,7 @@
 
 	&__title {
 		color: variables.$color--primary;
-		font-size: 1.25rem;
+		font-size: variables.$text--lg;
 	}
 
 	&__contact {

--- a/src/styles/page/PageHeader.scss
+++ b/src/styles/page/PageHeader.scss
@@ -8,13 +8,20 @@
 			display: flex;
 			gap: 2rem;
 			justify-content: space-between;
+
+			@media screen and (min-width: 48rem) and (max-width: 64rem) {
+				flex-direction: column;
+				align-items: center;
+				gap: 1rem;
+			}
+		
 		}
 
 		.Logo {
 			max-inline-size: 12rem;
 
 			@media screen and (min-width: 72rem) {
-				max-inline-size: 24rem;
+				max-inline-size: 16rem;
 			}
 		}
 	}

--- a/src/styles/page/PageSection.scss
+++ b/src/styles/page/PageSection.scss
@@ -47,7 +47,7 @@
 			.PageSection {
 				&__content {
 					color: white;
-					font-size: 1.125rem;
+					font-size: variables.$text--md;
 					position: relative;
 					z-index: 10;
 

--- a/src/styles/page/PageSection.scss
+++ b/src/styles/page/PageSection.scss
@@ -26,7 +26,7 @@
 		}
 
 		&__title {
-			font-size: 2rem;
+			font-size: variables.$text--2xl;
 		}
 
 		&__content {

--- a/src/styles/page/Post.scss
+++ b/src/styles/page/Post.scss
@@ -45,7 +45,7 @@
 		}
 
 		&__title {
-			font-size: 2.25rem;
+			font-size: variables.$text--2xl;
 			font-weight: 700;
 			line-height: 2.5rem;
 			margin-bottom: 1.5rem;

--- a/src/styles/page/Post.scss
+++ b/src/styles/page/Post.scss
@@ -51,7 +51,7 @@
 			margin-bottom: 1.5rem;
 
 			@media screen and (min-width: 48rem) {
-				font-size: 3rem;
+				font-size: variables.$text--3xl;
 				line-height: 1;
 			}
 		}

--- a/src/styles/page/SectionIndex.scss
+++ b/src/styles/page/SectionIndex.scss
@@ -1,3 +1,5 @@
+@use '../variables';
+
 @layer page {
 	.SectionIndex {
 		.container {
@@ -15,14 +17,14 @@
 
 			p {
 				max-width: 48rem;
-				font-size: 1.25rem;
+				font-size: variables.$text--lg;
 				line-height: 1.75rem;
 			}
 		}
 
 		&__title {
 			margin-bottom: 1.5rem;
-			font-size: 3rem;
+			font-size: variables.$text--3xl;
 			line-height: 1;
 			font-weight: 700;
 		}
@@ -63,7 +65,7 @@
 
 				strong {
 					margin-bottom: 1rem;
-					font-size: 1.5rem;
+					font-size: variables.$text--xl;
 					line-height: 2rem;
 					font-weight: 700;
 					color: #065f46;


### PR DESCRIPTION
## Summary
- fix responsive page header/nav behavior at in-between viewport widths to prevent overflow
- introduce shared SCSS text-size tokens in `src/styles/_variables.scss`
- normalize outlier and core `font-size` declarations to token usage across styles
- replace remaining Tailwind-style `text-*` size classes with project-native sizing

## Validation
- npm run build

## Context
This branch standardizes typography sizing across the site and includes a responsive navigation/header fix.

Branch: `fix-font-sizes-and-homepage-nav`

## What Changed

### Responsive navigation fix
- Updated page header sizing behavior to fix navigation at in-between viewport widths and prevent overflow on responsive screens.
- File: `src/styles/page/PageHeader.scss`
- Commit: `c779414` (`Fix the nav at in-between sizes to stop page overflow`)

#### Before
<img width="2404" height="984" alt="CleanShot 2026-04-08 at 08 59 52@2x" src="https://github.com/user-attachments/assets/0c90bbd2-44db-4c14-842f-7dd5012a06a1" />
<img width="1848" height="650" alt="CleanShot 2026-04-08 at 09 00 21@2x" src="https://github.com/user-attachments/assets/8373677d-5b07-42fd-80ed-6017e89c0507" />

<img width="1426" height="630" alt="CleanShot 2026-04-08 at 09 07 28@2x" src="https://github.com/user-attachments/assets/bd0611e1-ddf3-450b-92b6-0b483ac76ae7" />


#### After - introduce an inbetween step where logo above nav to allow for wide nav
<img width="2314" height="810" alt="CleanShot 2026-04-08 at 09 00 46@2x" src="https://github.com/user-attachments/assets/a2ea5ffc-c42e-4add-b8f2-d5e6c4a22e9a" />
<img width="1946" height="668" alt="CleanShot 2026-04-08 at 09 01 36@2x" src="https://github.com/user-attachments/assets/a003901e-2258-44be-abba-acedd9e22896" />
<img width="1478" height="794" alt="CleanShot 2026-04-08 at 09 01 52@2x" src="https://github.com/user-attachments/assets/64107a96-a76e-456b-9a9c-0a7727bb1d1d" />

Achievement stack on smaller screens
<img width="1486" height="1248" alt="CleanShot 2026-04-08 at 09 08 15@2x" src="https://github.com/user-attachments/assets/b7953e6e-a762-42ab-9787-b384c1880005" />


### 1) Added shared text-size tokens
Defined in `src/styles/_variables.scss`:

- `$text--2xs: 0.75rem`
- `$text--xs: 0.875rem`
- `$text--sm: 1rem`
- `$text--md: 1.125rem`
- `$text--lg: 1.25rem`
- `$text--xl: 1.5rem`
- `$text--2xl: 1.875rem`
- `$text--3xl: 3rem`
- `$text--display: 6rem`

### 2) First-pass outlier normalization
Mapped uncommon sizes onto the token scale:

- `1.0625rem` → `$text--sm`
- `1.1875rem` → `$text--md`
- `1.625rem` → `$text--xl`
- `2rem` → `$text--2xl`
- `2.25rem` → `$text--2xl`

Files:
- `src/styles/page/ContentBlock.scss`
- `src/styles/page/Post.scss`
- `src/styles/page/PageSection.scss`

### 3) Second-pass core literal replacement
Replaced repeated core literals in styles with tokens:

- `0.875rem`, `1rem`, `1.125rem`, `1.25rem`, `1.5rem`, `1.875rem`, `3rem`, `6rem`

Files:
- `src/styles/components/Achievements.scss`
- `src/styles/components/Article.scss`
- `src/styles/components/Navigation.scss`
- `src/styles/components/PressArticles.scss`
- `src/styles/components/Site.scss`
- `src/styles/components/TeamMembers.scss`
- `src/styles/global.scss`
- `src/styles/page/ContentHero.scss`
- `src/styles/page/Footer.scss`
- `src/styles/page/PageSection.scss`
- `src/styles/page/Post.scss`
- `src/styles/page/SectionIndex.scss`

### 4) Remaining non-token cleanup
- `Site.scss`: `0.75rem` → `$text--2xs`
- `ImageGallery.astro`: `1.125rem` → `$text--md` (style block converted to SCSS + shared variables import)
- `global.scss`: `100%` → `$text--sm`

Files:
- `src/components/ImageGallery.astro`
- `src/styles/components/Site.scss`
- `src/styles/global.scss`

### 5) Removed Tailwind-style text-size classes from active pages/components
Replaced `text-sm`, `text-lg`, `text-xl`, `text-3xl`, `text-5xl` with project-native sizing.

Files:
- `src/components/Pagination.astro`
- `src/pages/contact.astro`
- `src/pages/join-our-mailing-list.astro`
- `src/pages/people-and-families/well-help-you-buy-land.astro`
- `src/pages/sites/[slug].astro`

## Validation
- `npm run build` passes.
- No remaining `text-*` size utility classes in `src/pages` and `src/components`.
- `font-size` declarations are token-based in `src/styles` and `src/components/ImageGallery.astro`.

## Typography commits
- `b56a49d` first pass - normalise font sizes - outliers
- `96dc095` second pass - normalise font sizes - core tokens
- `c3e5bef` third pass - normalise font sizes - remaining non-token cases
- `46f78e7` fourth pass - replace tailwind text-size classes with tokens
