### PR TITLE
fix: correctly add subscribers to region "interest"

### DIFF
--- a/src/pages/api/subscribe.ts
+++ b/src/pages/api/subscribe.ts
@@ -11,6 +11,22 @@ const groupIds: Record<string, string | undefined> = {
 	volunteer: import.meta.env.MAILCHIMP_GROUP_ID_VOLUNTEER,
 };
 
+const regionInterestIds: Record<string, string> = {
+	'South West England': '8b2a4f085a',
+	'South East England': 'a8f7d9b61b',
+	'East of England': '68f0931a87',
+	'West Midlands': 'b4d8545587',
+	'East Midlands': '728073f1e7',
+	'Yorkshire & The Humber': '507d1ff31e',
+	'North West England': '3014d683a0',
+	'North East': '5d2e34e65d',
+	'North Wales': '498e864d45',
+	'South West Wales': '54ee790e75',
+	'Mid Wales': '7e8c207db0',
+	'South East Wales': 'b6cad07b51',
+	'Scotland': '5c5bdc385f',
+};
+
 mailchimp.setConfig({
 	apiKey: import.meta.env.MAILCHIMP_API_KEY,
 	server: import.meta.env.MAILCHIMP_SERVER_PREFIX,
@@ -52,7 +68,10 @@ export const POST: APIRoute = async ({ request }) => {
 			FNAME: firstName,
 		};
 		if (lastName) mergeFields.LNAME = lastName;
-		if (region) mergeFields.REGION = region;
+
+		const interests: Record<string, boolean> = { [groupId]: true };
+		const regionInterestId = region ? regionInterestIds[region] : undefined;
+		if (regionInterestId) interests[regionInterestId] = true;
 
 		const subscriberHash = createHash('md5').update(email.toLowerCase()).digest('hex');
 
@@ -60,7 +79,7 @@ export const POST: APIRoute = async ({ request }) => {
 			email_address: email,
 			status_if_new: 'pending',
 			merge_fields: mergeFields,
-			interests: { [groupId]: true },
+			interests,
 		});
 
 		const message =


### PR DESCRIPTION
Fixes: https://github.com/protect-earth/website/issues/34

I tested this with the user `greg+regiontest1@...` which you should hopefully see will have a region :)

---

Regions are a subset of the "interest" fields, each with their own ID. This mapping was exported from the API...

Assuming correct values in `.env`, first find the "Regions" category ID:

```
set -a; source .env; set +a

curl -s -u "anystring:$MAILCHIMP_API_KEY" \
  "https://$MAILCHIMP_SERVER_PREFIX.api.mailchimp.com/3.0/lists/$MAILCHIMP_AUDIENCE_ID/interest-categories" \
  | jq '.categories[] | {id, title}'
```

Which returns something like:

```
...
{
  "id": "<region-id>",
  "title": "Regions"
}
```

Followed by listing "interests" (regions) in that category:

```
curl -s -u "anystring:$MAILCHIMP_API_KEY" \
  "https://$MAILCHIMP_SERVER_PREFIX.api.mailchimp.com/3.0/lists/$MAILCHIMP_AUDIENCE_ID/interest-categories/<region-id-from-above>/interests?count=100" \
  | jq '.interests[] | {id, name}'
```