### PR TITLE
fix: Made video hero content not overlap with siblings [#40]

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,7 @@ import ArrowRight from '../assets/icons/arrow-right.svg';
 const latestPosts = (await getCollection('articles'))
 	.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
 	.slice(0, 4)
-	.map((post) => ({ slug: post.id, data: post.data }));
+	.map(post => ({ slug: post.id, data: post.data }));
 ---
 
 <Layout title="Home">
@@ -224,7 +224,7 @@ const latestPosts = (await getCollection('articles'))
 	.video-container {
 		clip-path: var(--wavy-line-top-bottom);
 		position: relative;
-		height: 100vh;
+		min-height: 100vh;
 		width: 100vw;
 		overflow: hidden;
 		display: flex;
@@ -262,9 +262,11 @@ const latestPosts = (await getCollection('articles'))
 		color: var(--body-text-light);
 		gap: var(--space-m);
 		padding-inline: var(--space-2xl);
+		padding-block: var(--space-3xl);
 		display: grid;
 		grid-template-columns: repeat(3, 1fr);
 		gap: var(--space-m);
+
 		@media screen and (max-width: 844px) {
 			padding-inline: var(--space-m);
 			display: flex;
@@ -394,8 +396,8 @@ const latestPosts = (await getCollection('articles'))
 	document.addEventListener('DOMContentLoaded', () => {
 		const video = document.getElementById('hero-video') as HTMLVideoElement | null;
 		if (video) {
-			video.play().catch((err) => console.error('Video play error:', err));
-			video.addEventListener('error', (e) => {
+			video.play().catch(err => console.error('Video play error:', err));
+			video.addEventListener('error', e => {
 				console.error('Video error:', e);
 				console.error('Video error details:', video.error);
 			});


### PR DESCRIPTION
The hero was overlapping because the nav bar was absolutely positioned. Added padding on both ends of the hero, and gave it a min-height and now works at all sizes.

Tested on Win/Firefox on all widths up to 1520px wide.

This fixes #40
