### PR TITLE
Improve Site Location to show all "Parcel" areas

### DIFF
--- a/scripts/sync-sites.js
+++ b/scripts/sync-sites.js
@@ -380,8 +380,12 @@ async function syncSites() {
 				delete frontmatter.images;
 			}
 
+			// Hardcode site ID to frontmatter for reference
+			frontmatter.siteId = site.id;
+
 			// Write the file
 			const newContent = matter.stringify(content, frontmatter);
+
 			fs.writeFileSync(filePath, newContent, 'utf8');
 
 			if (fileExists) {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -90,11 +90,12 @@ const siteMeta = defineCollection({
 	loader: glob({ base: './src/content/siteMeta', pattern: '**/*.md' }),
 	schema: ({ image }) =>
 		z.object({
-			siteId: z.string().optional(),
 			fundingPartners: z.array(z.string()).optional(),
 			tags: z.array(z.string()),
+			siteId: z.string().optional(),
 			notionIds: z.array(z.string()).optional(),
 			images: z.array(image()).optional(),
+			flagShowArea: z.boolean().optional(),
 		}),
 });
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -90,6 +90,7 @@ const siteMeta = defineCollection({
 	loader: glob({ base: './src/content/siteMeta', pattern: '**/*.md' }),
 	schema: ({ image }) =>
 		z.object({
+			siteId: z.string().optional(),
 			fundingPartners: z.array(z.string()).optional(),
 			tags: z.array(z.string()),
 			notionIds: z.array(z.string()).optional(),

--- a/src/content/siteMeta/aston-house-farm.md
+++ b/src/content/siteMeta/aston-house-farm.md
@@ -1,4 +1,0 @@
----
-fundingPartners: ['ecologi']
-tags: ['shelterbelt']
----

--- a/src/content/siteMeta/bethania.md
+++ b/src/content/siteMeta/bethania.md
@@ -15,5 +15,6 @@ images:
     ../../assets/sites/bethania/a43d918a129ec65f82a2495d3c40813422ca70ffc3b3d3f2e05fd8bc1989a65c.jpg
   - >-
     ../../assets/sites/bethania/d2afb2d76d205710321f5efadf2b652534eeb83611831c4d947b64a85f4ce656.jpg
+siteId: 019855f4-b9b6-7178-a7e2-95afd8ffd9eb
 ---
 

--- a/src/content/siteMeta/bilsborrow.md
+++ b/src/content/siteMeta/bilsborrow.md
@@ -12,5 +12,6 @@ images:
     ../../assets/sites/bilsborrow/d90ae72c70374caeb9e3ae1bd0fae371abcef0cff99c63e7ce29850e19d3639d.jpg
   - >-
     ../../assets/sites/bilsborrow/b75ae59c45462d727bc7a10afcb806d6aa219a2918ab7668a573cc17f3a68aa5.jpg
+siteId: 1d9449e6-1237-4f17-96bd-2e663cbe4609
 ---
 

--- a/src/content/siteMeta/bourton-on-the-water.md
+++ b/src/content/siteMeta/bourton-on-the-water.md
@@ -16,5 +16,6 @@ images:
     ../../assets/sites/bourton-on-the-water/d703d9f570472cfb7ccef910b4ceae8b662ef4ad6937a0520c13e1f24ce59b19.jpg
   - >-
     ../../assets/sites/bourton-on-the-water/39fd8aeeb6c38c53d48bf1b3424da5e3debeb9b081aa3b9a3733e53fa5a93873.jpg
+siteId: 582286a1-5781-4f67-b819-bf734d3cf1b6
 ---
 

--- a/src/content/siteMeta/box-colerne.md
+++ b/src/content/siteMeta/box-colerne.md
@@ -11,5 +11,6 @@ images:
     ../../assets/sites/box-colerne/9c0846eefef03dafb2333c188a12c786a418a3917db4632b4febfb25e66594fa.jpg
   - >-
     ../../assets/sites/box-colerne/bc316858b47772264ab505570d5571649743ae9f686687c37f27e161330e846d.jpg
+siteId: 01987ab0-6bf7-73d1-8368-8430aead2851
 ---
 

--- a/src/content/siteMeta/brimstone-farm.md
+++ b/src/content/siteMeta/brimstone-farm.md
@@ -6,5 +6,6 @@ tags:
 images:
   - >-
     ../../assets/sites/brimstone-farm/d16dcd1928590444af54298fd6a9e46ffb5df9d95f81a43f660be4193b4ce608.jpg
+siteId: ab5eb10b-74a8-45c8-b9c4-7202f80494f8
 ---
 

--- a/src/content/siteMeta/bubbenhall.md
+++ b/src/content/siteMeta/bubbenhall.md
@@ -18,5 +18,6 @@ images:
     ../../assets/sites/bubbenhall/dfcb28b1725131ff7ec9fbe43a7f6907e1c58d5bad3a4728853c131c29266caf.jpg
   - >-
     ../../assets/sites/bubbenhall/3607212da0dbb60381431b6b71a23016270c9908a70d8a0026ab4a7eb8c193f9.jpg
+siteId: 2a7721f4-327e-4825-87c8-c3312406a2a2
 ---
 

--- a/src/content/siteMeta/carradel-farm.md
+++ b/src/content/siteMeta/carradel-farm.md
@@ -3,5 +3,6 @@ fundingPartners:
   - woodland-trust
 tags:
   - woodland creation
+siteId: 09038308-5a37-4e3a-92c1-2b399a0b6aaa
 ---
 

--- a/src/content/siteMeta/coxbury-farm.md
+++ b/src/content/siteMeta/coxbury-farm.md
@@ -12,5 +12,6 @@ images:
     ../../assets/sites/coxbury-farm/10d9906d78cbe8397d5b7f06d452c98aee11b08464343882734dbde2d31996cc.jpg
   - >-
     ../../assets/sites/coxbury-farm/aadec1c9594a3f2ab7b49363a8a5c69739bbcc550a98b1d9587f60b51d798461.jpg
+siteId: 9ba024e0-3174-4437-947d-756d02baefea
 ---
 

--- a/src/content/siteMeta/dolberthog-wood.md
+++ b/src/content/siteMeta/dolberthog-wood.md
@@ -15,5 +15,5 @@ images:
   - >-
     ../../assets/sites/dolberthog-wood/3b4318788abb23eaed56882e53982682fe760b6100804ac0e6b5333855536365.jpg
 siteId: 019ab72d-40a0-728d-a560-52c1f67d6bf6
+flagShowArea: true
 ---
-

--- a/src/content/siteMeta/dolberthog-wood.md
+++ b/src/content/siteMeta/dolberthog-wood.md
@@ -2,7 +2,7 @@
 tags:
   - ancient woodland restoration
 notionIds:
-  - "1c7e7dc6-657c-8032-8d7b-e2dc291c23ba"
+  - 1c7e7dc6-657c-8032-8d7b-e2dc291c23ba
 images:
   - >-
     ../../assets/sites/dolberthog-wood/2f96004408a12fb18990b15977c162d800010a2a2193d80acb83a77bf49cadc3.jpg
@@ -14,4 +14,6 @@ images:
     ../../assets/sites/dolberthog-wood/fb58ead4057cbe80c33a7542a527e33e359ed7bf4283c6b3c460798cf6ec97c0.jpg
   - >-
     ../../assets/sites/dolberthog-wood/3b4318788abb23eaed56882e53982682fe760b6100804ac0e6b5333855536365.jpg
+siteId: 019ab72d-40a0-728d-a560-52c1f67d6bf6
 ---
+

--- a/src/content/siteMeta/dyrham-wood.md
+++ b/src/content/siteMeta/dyrham-wood.md
@@ -3,5 +3,6 @@ fundingPartners:
   - ecologi
 tags:
   - woodland creation
+siteId: 466b10d0-224a-462c-ab4e-81c29cc3421f
 ---
 

--- a/src/content/siteMeta/eastcourt-farm.md
+++ b/src/content/siteMeta/eastcourt-farm.md
@@ -18,5 +18,6 @@ images:
     ../../assets/sites/eastcourt-farm/3d02aeb55f10c8a838b69ee222eb7b7c3c975ef7848311029696d1870e7629e4.jpg
   - >-
     ../../assets/sites/eastcourt-farm/e2784bdf1d0ee6b5e1c0a77cac0c5799c37bba4f8b35960ff99cdfa8ecdff2b2.jpg
+siteId: 98028889-59ee-4417-823f-a1b69bcfe8a5
 ---
 

--- a/src/content/siteMeta/glebe-farm.md
+++ b/src/content/siteMeta/glebe-farm.md
@@ -14,5 +14,6 @@ images:
     ../../assets/sites/glebe-farm/0327a5e69b8551dc7c8c0d560ae99ae472675770032f79512044acf6b9b66480.jpg
   - >-
     ../../assets/sites/glebe-farm/7442acd7c70e0ca665b6334efa8bc7333759c65dfee6af90075a878c535a9e28.jpg
+siteId: 98698d7e-adcf-45b6-b2ed-1942e2290c8c
 ---
 

--- a/src/content/siteMeta/goytre-wood.md
+++ b/src/content/siteMeta/goytre-wood.md
@@ -22,5 +22,6 @@ images:
     ../../assets/sites/goytre-wood/7f8b8c70b39e5fded8f5ca02a934229da02befcce4cf24c444b5b4a8ef438295.jpg
   - >-
     ../../assets/sites/goytre-wood/93b88e451e82eaef50cfbbfccb46663ba1d82ef5e69ae365b577372fb6afd2e1.jpg
+siteId: 9f1710ea-85b7-40f6-a75f-bc56ac246ef5
 ---
 

--- a/src/content/siteMeta/guiting-manor-farm.md
+++ b/src/content/siteMeta/guiting-manor-farm.md
@@ -1,5 +1,6 @@
 ---
 tags:
   - shelterbelt
+siteId: b745f765-06c7-40c5-bbf6-1506e657c970
 ---
 

--- a/src/content/siteMeta/hardknott-forest.md
+++ b/src/content/siteMeta/hardknott-forest.md
@@ -18,5 +18,6 @@ images:
     ../../assets/sites/hardknott-forest/11817e975c8d7570c57004ad93cb7e18a34bd951382c18ff5911afb35fc078a6.jpg
   - >-
     ../../assets/sites/hardknott-forest/edb9110b61a519ac4a51c2409fa45fcfe968d38fce456daeec4a80c6cf8d8343.jpg
+siteId: 9abb3441-44d7-4b4b-89d5-bf544d4ee3c7
 ---
 

--- a/src/content/siteMeta/hawling.md
+++ b/src/content/siteMeta/hawling.md
@@ -38,5 +38,6 @@ images:
     ../../assets/sites/hawling/bebbb31aedfd0196c4319b09ead0a370e68ffde4cc8f891088f699ff5940f1a9.jpg
   - >-
     ../../assets/sites/hawling/9b969bef84ed7ed1ae9dbf340975bdfaee2495f17c9ded0d65760f5d4f80d3e8.jpg
+siteId: 9d4d7076-314e-4946-b938-6fdd170de67b
 ---
 

--- a/src/content/siteMeta/haydon-bridge.md
+++ b/src/content/siteMeta/haydon-bridge.md
@@ -14,5 +14,6 @@ images:
     ../../assets/sites/haydon-bridge/e7b8d6db1ab2ab3da63a368b8d02fbf816f82b31f5f039a906dc50c629e5dcd8.jpg
   - >-
     ../../assets/sites/haydon-bridge/8d474c6dae01cab9ef19b5501c78cbcfb960001386babd344dbf17334c16c079.jpg
+siteId: 97fefb9c-10bb-416a-88e5-08a85eebca8e
 ---
 

--- a/src/content/siteMeta/hazeland-wood.md
+++ b/src/content/siteMeta/hazeland-wood.md
@@ -12,5 +12,6 @@ images:
     ../../assets/sites/hazeland-wood/6f601e58fcb2da3e63a763698ae1aa0ac3285c06ccc6d56a4eb8d75319294924.jpg
   - >-
     ../../assets/sites/hazeland-wood/6898aeef2e6136f8055830f1cab229e4f31df1dbdb28544323396c169155f780.jpg
+siteId: 8d055b56-4df0-47e0-be04-072f1a82ed21
 ---
 

--- a/src/content/siteMeta/hemyock.md
+++ b/src/content/siteMeta/hemyock.md
@@ -14,5 +14,6 @@ images:
     ../../assets/sites/hemyock/e8d093ebdeaa233752eb97a38030fbc2be1fd899af3542b6f053bc74074a55ab.jpg
   - >-
     ../../assets/sites/hemyock/ba360f3896aa73843f8c30d873de36e8196baf3782ac20fc1bf1183920b18c2c.jpg
+siteId: 98d661e2-ded6-42f0-a5aa-a9333c19e8e3
 ---
 

--- a/src/content/siteMeta/highchurch-farm.md
+++ b/src/content/siteMeta/highchurch-farm.md
@@ -16,5 +16,6 @@ images:
     ../../assets/sites/highchurch-farm/3f0d7e96bcafa39b954e3878656547476089e73cde7ffcea2b9e937442350d91.jpg
   - >-
     ../../assets/sites/highchurch-farm/8009c4995a9e5c77ea2d459245a29de75a82fb647461906ffdba2e85d3118ce1.jpg
+siteId: ae60df70-5489-4a86-8839-fb958378c7ca
 ---
 

--- a/src/content/siteMeta/hitchin.md
+++ b/src/content/siteMeta/hitchin.md
@@ -21,5 +21,6 @@ images:
     ../../assets/sites/hitchin/d288374d3024ca6a48b6bf6ad1beb161de4a67be2565a099c77010fba4c492d4.jpg
   - >-
     ../../assets/sites/hitchin/671897967c8ec12219ab92278ea710435f17027411720dffaa05608946965f34.jpg
+siteId: 019836a0-422f-7182-8117-74211918446f
 ---
 

--- a/src/content/siteMeta/honeydale-farm.md
+++ b/src/content/siteMeta/honeydale-farm.md
@@ -3,5 +3,6 @@ tags:
   - shelterbelt
 notionIds:
   - 957d7419-386d-46a3-ba60-448777b51a06
+siteId: 96b67cc9-4877-47a9-98c6-7bd27d204250
 ---
 

--- a/src/content/siteMeta/howard-court.md
+++ b/src/content/siteMeta/howard-court.md
@@ -16,5 +16,6 @@ images:
     ../../assets/sites/howard-court/cbbd7ea4d3df997fb218c5aebc879d31c1ccd10f7102778656ae35bb3998598e.jpg
   - >-
     ../../assets/sites/howard-court/d351a956ae1f9d6d60dcbb8e32a2bd2e4969572afa5d7c71507cd53c95d1c790.jpg
+siteId: b5e691b5-6f17-4a7a-b9fd-1981c4fc259b
 ---
 

--- a/src/content/siteMeta/hutton-rudby.md
+++ b/src/content/siteMeta/hutton-rudby.md
@@ -16,5 +16,6 @@ images:
     ../../assets/sites/hutton-rudby/5db9a5801f90cd078c9a272aa5f9e9662a3b834143018bfb42f0403805fb54c9.jpg
   - >-
     ../../assets/sites/hutton-rudby/6fc79f4e6874d14b4ddd3722ef0db0d29bf0e7d804c39dc812919f22bbc8f0d8.jpg
+siteId: 97fef98a-d9c4-4204-bef6-9b79ce8b8f76
 ---
 

--- a/src/content/siteMeta/killkenny-farm.md
+++ b/src/content/siteMeta/killkenny-farm.md
@@ -8,5 +8,6 @@ images:
     ../../assets/sites/killkenny-farm/27f4b995c6546eb0ee2fbd44a756de63a90b72372109182068964c964cac1bc1.jpg
   - >-
     ../../assets/sites/killkenny-farm/f85e5e65f48d660765758e34291376a15453ab628dfe5cf74851b927b8a7e126.jpg
+siteId: 2708a946-34c1-495e-9719-661921999dbf
 ---
 

--- a/src/content/siteMeta/lainston.md
+++ b/src/content/siteMeta/lainston.md
@@ -14,5 +14,6 @@ images:
     ../../assets/sites/lainston/274834d50858e6712c347ac99f3f807e23f8169383f35ade4c642be36e04e737.jpg
   - >-
     ../../assets/sites/lainston/45edbb1dfc35912485e99312165cf4e750869d3c9a724f26b986b897df82cde6.jpg
+siteId: 9abafe48-70a4-4d89-b14f-6d4b8c0c6a16
 ---
 

--- a/src/content/siteMeta/liskeard.md
+++ b/src/content/siteMeta/liskeard.md
@@ -35,6 +35,7 @@ images:
     ../../assets/sites/liskeard/b6401003822b1bd7ac6bdf962ae9316431e7e32dd527fa32601a67b336557304.jpg
   - >-
     ../../assets/sites/liskeard/c058e33dd22bc0830d41631b5b524a77a122ce9685d11572737d5e41e4683eb9.jpg
+siteId: 8840cb37-9fa6-4ee3-be65-5a2260744d8c
 ---
 
 Protect Earth is now the proud owner of a historic 64-acre ancient woodland known as High Wood, in Liskeard, Cornwall. High Wood has a long history, with the old Caradon Mining Railway running through the middle of the land. Dog walkers love it, there are mountain bike trails, and there is huge potential here for restoring the woodland to its former glory as a temperate rainforest.

--- a/src/content/siteMeta/llangattock-forest-school.md
+++ b/src/content/siteMeta/llangattock-forest-school.md
@@ -3,5 +3,6 @@ fundingPartners:
   - ecologi
 tags:
   - woodland creation
+siteId: 9b7de6e4-4075-4e5e-8d8b-78c9b13d496b
 ---
 

--- a/src/content/siteMeta/low-fell.md
+++ b/src/content/siteMeta/low-fell.md
@@ -6,5 +6,6 @@ notionIds:
 images:
   - >-
     ../../assets/sites/low-fell/eeedca25cfb1b924641c010bb706d232db65eb9dabd9687d09bfd1407a62fa20.jpg
+siteId: 9defbb65-7041-45fd-b7c1-00765c4db4a8
 ---
 

--- a/src/content/siteMeta/lower-hampen-farm.md
+++ b/src/content/siteMeta/lower-hampen-farm.md
@@ -14,5 +14,6 @@ images:
     ../../assets/sites/lower-hampen-farm/0686923a6dd7814ee200fbbdaab1a88542d9b8344565f440d4a87d724f1722c2.jpg
   - >-
     ../../assets/sites/lower-hampen-farm/b5b36b258ea5a39c2ec7203898d395ea3e9eb6569d5edafa6988ba9157d615b0.jpg
+siteId: ae8f7907-926c-42a5-89cb-0e40a5cd1fc6
 ---
 

--- a/src/content/siteMeta/manaccan.md
+++ b/src/content/siteMeta/manaccan.md
@@ -26,5 +26,6 @@ images:
     ../../assets/sites/manaccan/ae01b082dd040b324e90047790fc93931981148d65d8ce30220263c77169393e.jpg
   - >-
     ../../assets/sites/manaccan/33b990f22738670ca67ae20b1d1ec7eb20f70fd983f7d62c134395fab13b4135.jpg
+siteId: 9b3bc343-83cd-4825-84c9-3e3dbf28b59b
 ---
 

--- a/src/content/siteMeta/manafon.md
+++ b/src/content/siteMeta/manafon.md
@@ -16,5 +16,6 @@ images:
     ../../assets/sites/manafon/91ccc198a83d42c43640ba31bf00de03efaa40b5afe51de34e96bab89a17d32e.jpg
   - >-
     ../../assets/sites/manafon/694b65c642d65e391ec5efc65877915b0b09bf274f0e13d127588f87edbedb49.jpg
+siteId: 9b7df47f-8f7a-43a5-a64e-6bfcad985205
 ---
 

--- a/src/content/siteMeta/mauchline.md
+++ b/src/content/siteMeta/mauchline.md
@@ -12,5 +12,6 @@ images:
     ../../assets/sites/mauchline/7c17e4151e93aa1dd8cb3e39cc8e0e2e211a6e921224b528e57159b0ffebf509.jpg
   - >-
     ../../assets/sites/mauchline/4e555e3409781ec8b5e476ae556303e8d53f41e35712afdd214c5fcde045bfb7.jpg
+siteId: 9db36f87-0c40-49ff-b7ce-b821a846b2ca
 ---
 

--- a/src/content/siteMeta/moat-farm.md
+++ b/src/content/siteMeta/moat-farm.md
@@ -10,5 +10,6 @@ images:
     ../../assets/sites/moat-farm/fecb0144cd267117d1b26a0ff8510617653f5b35b466052647b95b9931f98dd3.jpg
   - >-
     ../../assets/sites/moat-farm/167f56ef8bad56d9fdec78a17662a50265d3a6b27de0f1be8d8d79d26bbd16bd.jpg
+siteId: 9b2d92c9-4806-4ab0-a6b3-632e710d91ea
 ---
 

--- a/src/content/siteMeta/nannerch.md
+++ b/src/content/siteMeta/nannerch.md
@@ -18,5 +18,6 @@ images:
     ../../assets/sites/nannerch/5c373e6fe2f013aa57a34236b0d1e4b8c0c52a4da4d9c2585b7e5a907432da86.jpg
   - >-
     ../../assets/sites/nannerch/e7ecf95920f7a3f9eb530e60770782c5d93b496bb5f414f1a749fe6cd58163d0.jpg
+siteId: 9f4b3273-01dc-4afd-b289-bdec8ace72ba
 ---
 

--- a/src/content/siteMeta/newtown.md
+++ b/src/content/siteMeta/newtown.md
@@ -5,5 +5,6 @@ tags:
   - woodland creation
 notionIds:
   - 8f0fdd30-ce9b-483c-b569-b750e4061604
+siteId: 97d8587a-17fa-4a52-9796-27a0e3324592
 ---
 

--- a/src/content/siteMeta/pantpurlais.md
+++ b/src/content/siteMeta/pantpurlais.md
@@ -17,5 +17,6 @@ images:
     ../../assets/sites/pantpurlais/d9da2c6d9a05803f2dc4a8a22a5953b180aaf204e6849f51c76038d6674e801b.jpg
   - >-
     ../../assets/sites/pantpurlais/85b1515a83cbe2159135daffa4c09ba972636ac3a7d42c67e44f1e9cbc88de06.jpg
+siteId: 648b8347-a7b5-4acd-84fe-488c236877e3
 ---
 

--- a/src/content/siteMeta/pennyhill-park.md
+++ b/src/content/siteMeta/pennyhill-park.md
@@ -14,5 +14,6 @@ images:
     ../../assets/sites/pennyhill-park/416b6348671326305ed48c01f67d5ce3036639c5fb94da8cd0be117f0fa0d423.jpg
   - >-
     ../../assets/sites/pennyhill-park/28bc55575eec312296726fdafced337cfa03b54a582b6fa5399a33c9c9b20aa7.jpg
+siteId: 9abb199f-5ca3-4a7b-b5c6-c2dad7bebf13
 ---
 

--- a/src/content/siteMeta/rhydwen.md
+++ b/src/content/siteMeta/rhydwen.md
@@ -18,5 +18,6 @@ images:
     ../../assets/sites/rhydwen/01b32ea018c327f81df372845c0b5f378bdf2cfa018ae320739b64b6a1edd7da.jpg
   - >-
     ../../assets/sites/rhydwen/a4e87fe5199b3194703aaf92cab22bff60df85c6e96f721ef73f557ad83476d0.jpg
+siteId: 989bded2-7e2f-4fa0-85b3-17823db9f5c5
 ---
 

--- a/src/content/siteMeta/river-roding.md
+++ b/src/content/siteMeta/river-roding.md
@@ -15,4 +15,6 @@ images:
     ../../assets/sites/river-roding/aadc0825989f793791e7e4bcf94999a40485081da710bd3db0ba947a57a10591.jpg
   - >-
     ../../assets/sites/river-roding/a5c45d78f1366ff25d150d325724c0e15e0a6d5784e53d4ab72160672a4b8167.jpg
+siteId: 019e64ff-d6cf-702b-ad5f-3fc3122d60c5
 ---
+

--- a/src/content/siteMeta/romford.md
+++ b/src/content/siteMeta/romford.md
@@ -18,5 +18,6 @@ images:
     ../../assets/sites/romford/99d44452be5ca744bf88cf11664c91bd077420560e96d5c8dbca6f9b7d0e2276.jpg
   - >-
     ../../assets/sites/romford/9c37ca4fe983c03a693577de0f2730067ff459a9c3e5ab6c9fcdd79bdd31ee10.jpg
+siteId: 01983256-3ca4-720b-a7d8-210468e2b83d
 ---
 

--- a/src/content/siteMeta/saddleworth.md
+++ b/src/content/siteMeta/saddleworth.md
@@ -12,5 +12,6 @@ images:
     ../../assets/sites/saddleworth/3ffe6f6853c949a9fd841ebb3f7da021eea5224658c215f6d1e68950981116e0.jpg
   - >-
     ../../assets/sites/saddleworth/c9f465b8a8acd2da1a5127071572e467a99a8fe9df4ce20178b153c84deb4890.jpg
+siteId: 0199be63-af5d-70df-91ea-3b7f497db2e8
 ---
 

--- a/src/content/siteMeta/shillingford.md
+++ b/src/content/siteMeta/shillingford.md
@@ -14,5 +14,6 @@ images:
     ../../assets/sites/shillingford/64382865a72a4e4feb70061ecad4ffece4184143606319d6e8fb5b1d9bc802d3.jpg
   - >-
     ../../assets/sites/shillingford/6727b36e3c3a1b74bd7683dda96d4286abaa9069b16480e3751f7ac2ba917db9.jpg
+siteId: 97f8a2f6-b31b-4f6d-84f8-53940f72d1a8
 ---
 

--- a/src/content/siteMeta/south-barrow.md
+++ b/src/content/siteMeta/south-barrow.md
@@ -16,5 +16,6 @@ images:
     ../../assets/sites/south-barrow/f799457865a4ec1df51c6274364bb15cfa0438ba7dfc69e9815a0f27ad003b77.jpg
   - >-
     ../../assets/sites/south-barrow/7fe8ac8fdb1a8c91d99da3c8b736d3961ab07e352f5ba11fd1ddde9d0449a716.jpg
+siteId: 9ba87296-80d9-4048-beae-b04145c96bfa
 ---
 

--- a/src/content/siteMeta/south-lodge.md
+++ b/src/content/siteMeta/south-lodge.md
@@ -14,5 +14,6 @@ images:
     ../../assets/sites/south-lodge/849b24d78277d063289e67f1c9c09c01dcbac8808e8c3060cff2b52227a3398d.jpg
   - >-
     ../../assets/sites/south-lodge/6ca04d7aa49a973ca8f8ebdf9d05b7e7ecc351f2673160c3d67a242ae1ea52c0.jpg
+siteId: 98028f24-20fd-40ba-bac6-3f12524c7a16
 ---
 

--- a/src/content/siteMeta/south-molton.md
+++ b/src/content/siteMeta/south-molton.md
@@ -24,5 +24,6 @@ images:
     ../../assets/sites/south-molton/e11e8b2c3bb1a314c2e57867c38a98588238654362cdf43b71d218e186c50d66.jpg
   - >-
     ../../assets/sites/south-molton/9fc5cffb19fd938911501cd517a1edb00dd9fe04485eda260efc3e7618413cf0.jpg
+siteId: 9b018e0a-c103-45f6-80f5-6fef5fdba071
 ---
 

--- a/src/content/siteMeta/st-donats-castle.md
+++ b/src/content/siteMeta/st-donats-castle.md
@@ -14,5 +14,6 @@ images:
     ../../assets/sites/st-donats-castle/de95a5cd70f1eac89bbe7b8d39694083cc31bb7b7a09eb37dcc9056184ac5df7.jpg
   - >-
     ../../assets/sites/st-donats-castle/7f3611c9def65a69e22dcf3bf7a073046620e29862637068851008d74768c4e2.jpg
+siteId: 9ba036df-950f-416b-aefe-36746d1ae328
 ---
 

--- a/src/content/siteMeta/st-mary-st-john-primary-school.md
+++ b/src/content/siteMeta/st-mary-st-john-primary-school.md
@@ -13,5 +13,6 @@ images:
     ../../assets/sites/st-mary-st-john-primary-school/42f1ae9133845e14ae1e3065254b9dc2bbbbcb1c4f1a694b9e5d55f882ce2aff.jpg
   - >-
     ../../assets/sites/st-mary-st-john-primary-school/69af4ddc98c9bfc920832ada9794aab09582ea4733f6048509ab09e15dcc0e58.jpg
+siteId: 019bd169-8c5d-7116-aede-55e04b232510
 ---
 

--- a/src/content/siteMeta/stainswick-farm.md
+++ b/src/content/siteMeta/stainswick-farm.md
@@ -12,5 +12,6 @@ images:
     ../../assets/sites/stainswick-farm/023f80e8cc0fd807b6eaa59218b74114d00b7a3d401eedd4431aa967d2d1ba97.jpg
   - >-
     ../../assets/sites/stainswick-farm/522f7d80eeaff045decec224ba7168f452a21a5e667373220d5669242593b737.jpg
+siteId: e59a3d92-3681-4c15-b232-fe31790d32a5
 ---
 

--- a/src/content/siteMeta/stawley.md
+++ b/src/content/siteMeta/stawley.md
@@ -19,5 +19,6 @@ images:
     ../../assets/sites/stawley/4b28ee291df670f2f9255a4b6ec3eaa8ca2ad6384d17ddc6a59e608e6e919475.jpg
   - >-
     ../../assets/sites/stawley/ef4dd211558ce728620a4bbd3d6330e9523669bfb46729874831c8555376d39a.jpg
+siteId: 019837a9-f74d-7063-a87c-01194a38d9f7
 ---
 

--- a/src/content/siteMeta/thorncombe-street.md
+++ b/src/content/siteMeta/thorncombe-street.md
@@ -14,5 +14,6 @@ images:
     ../../assets/sites/thorncombe-street/47bbc6fa082e33ccfec275f4b1b5840f7dd5deed0499ce58456af5c37f346c8d.jpg
   - >-
     ../../assets/sites/thorncombe-street/df7ec1959f59e843b84e3905a8b57dd2978adeea9e48fda1e6f222a6ec9e2827.jpg
+siteId: 985d9436-2da7-4107-8345-16d52dd41c14
 ---
 

--- a/src/content/siteMeta/upp-hall-farm.md
+++ b/src/content/siteMeta/upp-hall-farm.md
@@ -12,5 +12,6 @@ images:
     ../../assets/sites/upp-hall-farm/c9d1829c453bf7f94f50d793cd4965bf530c526ef2c338af8a1eb80144534050.jpg
   - >-
     ../../assets/sites/upp-hall-farm/acc04474692abf9da1f6342a4ba4f04e86d078193dcc286cfdb5146299b1231b.jpg
+siteId: 978e9c9e-d2b6-41fa-889d-e771f8e88341
 ---
 

--- a/src/content/siteMeta/upper-pengethley-farm.md
+++ b/src/content/siteMeta/upper-pengethley-farm.md
@@ -10,5 +10,6 @@ images:
     ../../assets/sites/upper-pengethley-farm/b286005b511abaac8e6ee759f7ea1165dd2cefb08b428366e166e6bafb582113.jpg
   - >-
     ../../assets/sites/upper-pengethley-farm/d07f6abfaf13fb93117b70a7df58c33781da08ceeb5156235c51383d2e15ffa9.jpg
+siteId: 9baa8384-3a0f-4abd-954b-979353a45c31
 ---
 

--- a/src/content/siteMeta/wadswick-green.md
+++ b/src/content/siteMeta/wadswick-green.md
@@ -14,5 +14,6 @@ images:
     ../../assets/sites/wadswick-green/ae764e382f9814d2997564e29acb8752ba373435f2dfd63af54d15288c9f972f.jpg
   - >-
     ../../assets/sites/wadswick-green/8a81bec18bc053605aca4ab1af724bbedf17ca9dd12dc9572fa7138267fe51fd.jpg
+siteId: be5fd21e-fdad-45f7-9f78-a474d0174e5c
 ---
 

--- a/src/content/siteMeta/weston-farm.md
+++ b/src/content/siteMeta/weston-farm.md
@@ -12,5 +12,6 @@ images:
     ../../assets/sites/weston-farm/636cd5c7e2a72bacace456d7eaeb3415fe5c5b93917fd38d3440800f7b0e5406.jpg
   - >-
     ../../assets/sites/weston-farm/8d075d1c5beb2be5160c78250a6ada1c3aa67123c386f85fa2de3f4b79980f49.jpg
+siteId: d509e14a-49fb-4875-a173-498288c24dd3
 ---
 

--- a/src/content/siteMeta/woodlea.md
+++ b/src/content/siteMeta/woodlea.md
@@ -20,5 +20,6 @@ images:
     ../../assets/sites/woodlea/b5ada88dde4e5e8afb921af03eaa8038903fe2b6c92b55734d3d5aca115efefe.jpg
   - >-
     ../../assets/sites/woodlea/fb255b8519eac3caf90bb6a7ab7651b3be5ae62a8c5f9194ffca77a7630706f7.jpg
+siteId: 9773b06b-8ba5-416d-901a-0222255a9106
 ---
 

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -17,17 +17,7 @@ export async function getStaticPaths() {
 const { event } = Astro.props as { event: CollectionEntry<'events'> };
 
 const {
-	data: {
-		address,
-		description,
-		endDate,
-		eventbriteLink,
-		images,
-		map,
-		startDate,
-		title,
-		thumbnail,
-	},
+	data: { address, description, endDate, eventbriteLink, images, map, startDate, title, thumbnail },
 } = event;
 const customCta = (event.data as { customCta?: string }).customCta;
 const startDateValue = startDate as Date | undefined;
@@ -150,7 +140,6 @@ const { Content } = await render(event);
 							</>
 						)
 					}
-
 				</dl>
 			</div>
 

--- a/src/pages/sites/[slug].astro
+++ b/src/pages/sites/[slug].astro
@@ -80,6 +80,7 @@ const siteName = apiData?.name || site.id;
 const siteLocation = apiData?.location || '';
 const treeCount = apiData?.allocatedUnits || 0;
 const coordinates = apiData?.coordinates;
+const siteId = site.data.siteId;
 // Use images directly from content collection
 const images = site.data.images || [];
 const heroImage = images[0] || null;
@@ -87,6 +88,34 @@ const fundingPartners = site.data.fundingPartners || [];
 const siteDescription = apiData?.description;
 const descriptionHtml = siteDescription ? await marked.parse(siteDescription) : '';
 const species = apiData?.species || [];
+
+let siteMapGeoJson: any = null;
+if (siteId) {
+	try {
+		const mapResponse = await fetch(`https://api.protect.earth/maps/sites/${siteId}`);
+		if (mapResponse.ok) {
+			const mapData = await mapResponse.json();
+			if (mapData?.type === 'FeatureCollection' && Array.isArray(mapData.features)) {
+				const polygonFeatures = mapData.features.filter((feature: any) => {
+					const geometryType = feature?.geometry?.type;
+					return geometryType === 'Polygon' || geometryType === 'MultiPolygon';
+				});
+
+				if (polygonFeatures.length > 0) {
+					siteMapGeoJson = {
+						type: 'FeatureCollection',
+						features: polygonFeatures,
+					};
+				}
+			}
+		}
+	} catch (error) {
+		console.warn(`Could not load map polygons for ${site.id}:`, (error as Error).message);
+	}
+}
+
+const hasCoordinates = Boolean(coordinates && coordinates.latitude && coordinates.longitude);
+const hasMapData = hasCoordinates || Boolean(siteMapGeoJson);
 
 // Funding partner logo mapping
 type FundingPartnerInfo = { src: string; alt: string; url: string };
@@ -270,7 +299,7 @@ const fundingPartnerInfos = fundingPartners
 
 		<!-- Map Section -->
 		{
-			coordinates && coordinates.latitude && coordinates.longitude && (
+			hasMapData && (
 				<section>
 					<h2>
 						<MapPin height={36} width={36} /> Site Location
@@ -364,23 +393,82 @@ const fundingPartnerInfos = fundingPartners
 <link href="https://api.mapbox.com/mapbox-gl-js/v2.8.2/mapbox-gl.css" rel="stylesheet" />
 <script src="https://api.mapbox.com/mapbox-gl-js/v2.8.2/mapbox-gl.js"></script>
 
-<script is:inline define:vars={{ coordinates, siteName, mapboxToken }}>
-	if (coordinates && coordinates.latitude && coordinates.longitude) {
+<script is:inline define:vars={{ coordinates, siteName, mapboxToken, siteMapGeoJson }}>
+	if ((coordinates && coordinates.latitude && coordinates.longitude) || siteMapGeoJson) {
 		document.addEventListener('DOMContentLoaded', () => {
 			mapboxgl.accessToken = mapboxToken;
+
+			const defaultCenter = coordinates
+				? [coordinates.longitude, coordinates.latitude]
+				: [-2.5, 54.0];
 
 			const map = new mapboxgl.Map({
 				container: 'map',
 				style: 'mapbox://styles/mapbox/satellite-v9',
-				center: [coordinates.longitude, coordinates.latitude],
+				center: defaultCenter,
 				zoom: 15,
 			});
 
 			map.addControl(new mapboxgl.NavigationControl());
 
-			new mapboxgl.Marker({ color: '#15803d' })
-				.setLngLat([coordinates.longitude, coordinates.latitude])
-				.addTo(map);
+			map.on('load', () => {
+				const hasPolygonFeatures =
+					siteMapGeoJson &&
+					siteMapGeoJson.type === 'FeatureCollection' &&
+					Array.isArray(siteMapGeoJson.features) &&
+					siteMapGeoJson.features.length > 0;
+
+				if (hasPolygonFeatures) {
+					map.addSource('site-boundary', {
+						type: 'geojson',
+						data: siteMapGeoJson,
+					});
+
+					map.addLayer({
+						id: 'site-boundary-fill',
+						type: 'fill',
+						source: 'site-boundary',
+						paint: {
+							'fill-color': '#16a34a',
+							'fill-opacity': 0.3,
+						},
+					});
+
+					map.addLayer({
+						id: 'site-boundary-line',
+						type: 'line',
+						source: 'site-boundary',
+						paint: {
+							'line-color': '#166534',
+							'line-width': 2,
+						},
+					});
+
+					const bounds = new mapboxgl.LngLatBounds();
+					siteMapGeoJson.features.forEach((feature) => {
+						const geometry = feature?.geometry;
+						if (!geometry?.coordinates) return;
+
+						if (geometry.type === 'Polygon') {
+							geometry.coordinates.flat().forEach((coordinate) => bounds.extend(coordinate));
+						}
+
+						if (geometry.type === 'MultiPolygon') {
+							geometry.coordinates
+								.flat(2)
+								.forEach((coordinate) => bounds.extend(coordinate));
+						}
+					});
+
+					if (!bounds.isEmpty()) {
+						map.fitBounds(bounds, { padding: 40, maxZoom: 16 });
+					}
+				} else if (coordinates && coordinates.latitude && coordinates.longitude) {
+					new mapboxgl.Marker({ color: '#15803d' })
+						.setLngLat([coordinates.longitude, coordinates.latitude])
+						.addTo(map);
+				}
+			});
 		});
 	}
 </script>

--- a/src/pages/sites/[slug].astro
+++ b/src/pages/sites/[slug].astro
@@ -81,6 +81,7 @@ const siteLocation = apiData?.location || '';
 const treeCount = apiData?.allocatedUnits || 0;
 const coordinates = apiData?.coordinates;
 const siteId = site.data.siteId;
+const flagShowArea = site.data.flagShowArea;
 // Use images directly from content collection
 const images = site.data.images || [];
 const heroImage = images[0] || null;
@@ -90,7 +91,7 @@ const descriptionHtml = siteDescription ? await marked.parse(siteDescription) : 
 const species = apiData?.species || [];
 
 let siteMapGeoJson: any = null;
-if (siteId) {
+if (flagShowArea && siteId) {
 	try {
 		const mapResponse = await fetch(`https://api.protect.earth/maps/sites/${siteId}`);
 		if (mapResponse.ok) {
@@ -424,22 +425,23 @@ const fundingPartnerInfos = fundingPartners
 						data: siteMapGeoJson,
 					});
 
-					map.addLayer({
-						id: 'site-boundary-fill',
-						type: 'fill',
-						source: 'site-boundary',
-						paint: {
-							'fill-color': '#16a34a',
-							'fill-opacity': 0.3,
-						},
-					});
+					// No fill for now
+					// map.addLayer({
+					// 	id: 'site-boundary-fill',
+					// 	type: 'fill',
+					// 	source: 'site-boundary',
+					// 	paint: {
+					// 		'fill-color': '#166534',
+					// 		'fill-opacity': 0.3,
+					// 	},
+					// });
 
 					map.addLayer({
 						id: 'site-boundary-line',
 						type: 'line',
 						source: 'site-boundary',
 						paint: {
-							'line-color': '#166534',
+							'line-color': '#4400a9',
 							'line-width': 2,
 						},
 					});
@@ -454,9 +456,7 @@ const fundingPartnerInfos = fundingPartners
 						}
 
 						if (geometry.type === 'MultiPolygon') {
-							geometry.coordinates
-								.flat(2)
-								.forEach((coordinate) => bounds.extend(coordinate));
+							geometry.coordinates.flat(2).forEach((coordinate) => bounds.extend(coordinate));
 						}
 					});
 


### PR DESCRIPTION
## Summary

Relates to #37.

I've done the API work to make site areas available when possible. This is on a special /map/sites/{uuid} endpoint and returns GeoJSON. I've hidden it behind a feature flag so each site will need to enable areas on the map as many of our areas are wrong right now. I'll go through fixing them up, adding the flags, then when its all good I'll remove the flags.

## Checklist

- [x] [CONTRIBUTING.md](../CONTRIBUTING.md) has been read
- [x] `pnpm build` passes
- [x] `pnpm format:write` has been run

## Screenshots

The green is no good on a satelite map so I'll try and mess with the colouring, and we need to start labeling what sort of work and putting in metrics, but this is still a WIP.

<img width="1382" height="613" alt="Screenshot 2026-06-03 at 5 34 37 PM" src="https://github.com/user-attachments/assets/0d695bd0-5d64-445d-91b9-c09eef26a0a7" />

This design is rubbish and doesnt show any metrics or particulars (is it woodland or wildflower meadow or what?) but I would love to roll it out and iterate on that later.

